### PR TITLE
Add hash map

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,9 @@
 require "bundler/gem_tasks"
 require 'rake/testtask'
 
-Rake::TestTask.new do |t|
-  t.libs << 'spec'
-  t.pattern = "spec/**/*_spec.rb"
+desc "run all the specs"
+task :test do
+  sh "rspec spec"
 end
+task :default => :test
+task :spec => :test

--- a/lib/norton.rb
+++ b/lib/norton.rb
@@ -7,6 +7,7 @@ require "norton/timestamp"
 require "norton/counter"
 require "norton/timed_value"
 require "norton/helper"
+require "norton/objects/hash_map"
 
 module Norton
   class << self

--- a/lib/norton.rb
+++ b/lib/norton.rb
@@ -8,8 +8,11 @@ require "norton/counter"
 require "norton/timed_value"
 require "norton/helper"
 require "norton/objects/hash_map"
+require "norton/hash"
 
 module Norton
+  class NilObjectId < StandardError; end
+
   class << self
     attr_accessor :redis
 

--- a/lib/norton/hash.rb
+++ b/lib/norton/hash.rb
@@ -1,0 +1,25 @@
+module Norton
+  module Hash
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def hash_map(name)
+        define_method(name) do
+          instance_variable_get("@#{name}") ||
+            instance_variable_set("@#{name}",
+              Norton::Objects::HashMap.new(norton_field_key(name))
+            )
+        end
+      end
+    end
+
+    def norton_field_key(name)
+      if id.nil?
+        raise NilObjectId,
+          "Attempt to address norton field :#{name} on class #{self.class.name} with nil id"
+      end
+
+      "#{self.class.name.tableize}:#{id}:#{name}"
+    end
+  end
+end

--- a/lib/norton/objects/hash_map.rb
+++ b/lib/norton/objects/hash_map.rb
@@ -1,0 +1,57 @@
+module Norton
+  module Objects
+    class HashMap
+      attr_reader :key
+
+      def initialize(key)
+        @key = key
+      end
+
+      # Redis: HSET
+      def hset(field, value)
+        Norton.redis.with { |conn| conn.hset(key, field, value) }
+      end
+      alias_method :[]=, :hset
+
+      # Redis: HGET
+      def hget(field)
+        Norton.redis.with { |conn| conn.hget(key, field) }
+      end
+      alias_method :get, :hget
+      alias_method :[],  :hget
+
+      # Redis: HDEL
+      def hdel(*field)
+        Norton.redis.with { |conn| conn.hdel(key, field) }
+      end
+      alias_method :delete, :hdel
+
+      # Redis: HINCRBY
+      def hincrby(field, by = 1)
+        Norton.redis.with { |conn| conn.hincrby(key, field, by) }
+      end
+      alias_method :incr, :hincrby
+
+      # Redis: HINCRBY
+      def hdecrby(field, by = 1)
+        hincrby(field, -by)
+      end
+      alias_method :decr, :hdecrby
+
+      # Redis: HEXISTS
+      def hexists(field)
+        Norton.redis.with { |conn| conn.hexists(key, field) }
+      end
+      alias_method :include?, :hexists
+      alias_method :has_key?, :hexists
+      alias_method :key?,     :hexists
+      alias_method :member?,  :hexists
+
+      # Redis: HEXISTS
+      def hkeys
+        Norton.redis.with { |conn| conn.hkeys(key) }
+      end
+      alias_method :keys, :hkeys
+    end
+  end
+end

--- a/spec/norton/hash_spec.rb
+++ b/spec/norton/hash_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+class HashObject
+  include Norton::Hash
+
+  hash_map :profile
+
+  def id
+    @id ||= 99
+  end
+end
+
+describe Norton::Hash do
+  describe "#norton_field_key" do
+    it "generates the correct field key" do
+      object = HashObject.new
+      expect(object.norton_field_key(:profile)).to eq("hash_objects:99:profile")
+    end
+
+    it "raises NilObjectId if the object id is nil" do
+      object = HashObject.new
+      allow(object).to receive(:id) { nil }
+
+      expect { object.norton_field_key(:profile) }.to raise_error(Norton::NilObjectId)
+    end
+  end
+
+  describe "#hash_map" do
+    it "sets a instance variable" do
+      object = HashObject.new
+      expect(object.profile).to be_a(Norton::Objects::HashMap)
+    end
+  end
+end

--- a/spec/norton/objects/hash_map_spec.rb
+++ b/spec/norton/objects/hash_map_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe Norton::Objects::HashMap do
+  describe "#hset" do
+    it "saves the value of the field in redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+      expect(Norton.redis.with { |conn| conn.hget(hash_map.key, :name) }).to eq("Bob")
+    end
+  end
+
+  describe "#hget" do
+    it "returns the value of the field from redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+
+      expect(hash_map.hget(:name)).to eq("Bob")
+    end
+  end
+
+  describe "#hdel" do
+    it "deletes the field from redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+
+      hash_map.hdel(:name)
+
+      expect(hash_map.hget(:name)).to be(nil)
+    end
+
+    it "deletes multiple fields from redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+      hash_map.hset(:age, 21)
+
+      hash_map.hdel(:name, :age)
+
+      expect(hash_map.hget(:name)).to be(nil)
+      expect(hash_map.hget(:age)).to be(nil)
+    end
+  end
+
+  describe "#hincrby" do
+    it "increments value by integer at field" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:age, 21)
+
+      hash_map.hincrby(:age, 2)
+      expect(hash_map.hget(:age)).to eq("23")
+    end
+
+    it "increments value by 1" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:age, 21)
+
+      hash_map.hincrby(:age)
+      expect(hash_map.hget(:age)).to eq("22")
+    end
+  end
+
+  describe "#hdecrby" do
+    it "decrements value by integer at field" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:age, 21)
+
+      hash_map.hdecrby(:age, 2)
+      expect(hash_map.hget(:age)).to eq("19")
+    end
+  end
+
+  describe "#hexists" do
+    it "returns true if the field exists in redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+
+      expect(hash_map.hexists(:name)).to be(true)
+    end
+
+    it "returns false if the field doesn't exist in redis" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+
+      expect(hash_map.hexists(:name)).to be(false)
+    end
+  end
+
+  describe "#hkeys" do
+    it "returns all keys in a hash" do
+      hash_map = Norton::Objects::HashMap.new("users:99:profile")
+      hash_map.hset(:name, "Bob")
+      hash_map.hset(:age, 21)
+
+      expect(hash_map.hkeys).to match_array(["name", "age"])
+    end
+  end
+end


### PR DESCRIPTION
支持定义 `Hash` 数据类型

Example:

``` ruby
class Person
  include Norton::Hash

  hash_map :profile

  def id
    99
  end
end

bob = Person.new
bob.profile["name"]   = "bob"
bob.profile["age"]    = 21
bob.profile["gender"] = "male"

bob.profile.get(:name)
 => "bob"

bob.profile.incr(:age)
 => "22"

bob.profile.delete(:gender)
 => 1
```